### PR TITLE
Add newline after CHAR_BIT definition in limits.h

### DIFF
--- a/libs/limits.go
+++ b/libs/limits.go
@@ -15,7 +15,7 @@ const (
 func init() {
 	RegisterLibrary(limitsH, func(c *Env) *Library {
 		var buf strings.Builder
-		buf.WriteString("#define CHAR_BIT 8")
+		buf.WriteString("#define CHAR_BIT 8\n")
 
 		idents := make(map[string]*types.Ident)
 		intMinMax(&buf, idents, "SCHAR", "Int", math.MinInt8, math.MaxInt8, 8)


### PR DESCRIPTION
I noticed that some code I was trying to tranpile was complaining about
CHAR_BITS not being defined after including <limits.h>.   The cause
was a missing new-line after CHAR_BIT was written to the limits buffer.