### PR TITLE
Use GetLibrary in more places

### DIFF
--- a/libs/config.go
+++ b/libs/config.go
@@ -52,7 +52,10 @@ func (c *Env) ResolveImport(name string) string {
 	return path
 }
 
-func (c *Env) GetLib(name string) *Library {
+// LookupLibrary finds an already loaded Library. It is useful to prevent import loops.
+//
+// Typically, the GetLibrary function should be used instead, because it will load the library automatically, if needed.
+func (c *Env) LookupLibrary(name string) *Library {
 	l, ok := c.libs[name]
 	if !ok {
 		panic(errors.New("cannot find library: " + name))

--- a/libs/pthread.go
+++ b/libs/pthread.go
@@ -15,8 +15,7 @@ func init() {
 		intT := types.IntT(4)
 		argT := c.PtrT(nil)
 		retT := c.PtrT(nil)
-		timeLib := c.GetLib(timeH)
-		timespecT := timeLib.GetType("timespec")
+		timespecT := c.GetLibraryType(timeH, "timespec")
 		threadT := types.NamedTGo("pthread_t", "pthread.Thread", c.MethStructT(map[string]*types.FuncType{
 			"Join":        c.FuncTT(intT, c.PtrT(retT)),
 			"TimedJoinNP": c.FuncTT(intT, c.PtrT(retT), c.PtrT(timespecT)),

--- a/libs/registry.go
+++ b/libs/registry.go
@@ -129,6 +129,7 @@ var defPathReplacer = strings.NewReplacer(
 	".", "_",
 )
 
+// GetLibrary finds or initializes the library, given a C include filename.
 func (c *Env) GetLibrary(name string) (*Library, bool) {
 	if l, ok := c.libs[name]; ok {
 		return l, true
@@ -177,6 +178,7 @@ func (c *Env) GetLibrary(name string) (*Library, bool) {
 	return l, true
 }
 
+// GetLibraryType is a helper for GetLibrary followed by GetType.
 func (c *Env) GetLibraryType(lib, typ string) types.Type {
 	l, ok := c.GetLibrary(lib)
 	if !ok {

--- a/libs/sys_socket.go
+++ b/libs/sys_socket.go
@@ -17,7 +17,7 @@ func init() {
 		gintT := c.Go().Int()
 		uintT := types.UintT(4)
 		bytesT := c.C().String()
-		inAddrT := c.GetLib(arpaInetH).GetType("in_addr")
+		inAddrT := c.GetLibraryType(arpaInetH, "in_addr")
 		sockAddrT := types.NamedT("cnet.SockAddr", types.StructT([]*types.Field{
 			{Name: types.NewIdentGo("sa_family", "Family", int16T)},
 			{Name: types.NewIdentGo("sa_data", "Data", c.C().BytesN(14))},

--- a/libs/sys_time.go
+++ b/libs/sys_time.go
@@ -12,7 +12,7 @@ const (
 func init() {
 	RegisterLibrary(sysTimeH, func(c *Env) *Library {
 		intT := types.IntT(4)
-		timeLib := c.GetLib(timeH)
+		timeLib := c.LookupLibrary(timeH)
 		timevalT := timeLib.GetType("timeval")
 		timespecT := timeLib.GetType("timespec")
 		_ = timespecT

--- a/libs_test.go
+++ b/libs_test.go
@@ -61,6 +61,22 @@ func foo() {
 `,
 	},
 	{
+		name: "sys socket",
+		src: `
+#include <sys/socket.h>
+
+void foo() {
+	in_addr_t a = inet_addr("1.2.3.4");
+}
+`,
+		exp: `
+func foo() {
+	var a cnet.Addr = cnet.ParseAddr("1.2.3.4")
+	_ = a
+}
+`,
+	},
+	{
 		name: "math",
 		src: `
 #include <math.h>


### PR DESCRIPTION
Use `GetLibrary` or `GetLibraryType` in more places, document them, and rename `GetLib` to `LookupLibrary`. Add a test case for #26 as well.

Fixes #26