### PR TITLE
release: fix goreleaser flow

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,6 +4,11 @@ before:
 builds:
   - id: cxgo
     main: ./cmd/cxgo
+    ldflags:
+      - -s -w
+      - -X main.version={{ .Tag }}
+      - -X main.commit={{ .Commit }}
+      - -X main.date={{ .Date }}
     env:
       - CGO_ENABLED=0
     goos:

--- a/cmd/cxgo/main.go
+++ b/cmd/cxgo/main.go
@@ -29,7 +29,7 @@ var Root = &cobra.Command{
 	RunE:  run,
 }
 
-const (
+var (
 	version = "dev"
 	commit  = ""
 	date    = ""


### PR DESCRIPTION
right now `cxgo version` prints `dev`, this PR is fixing the goreleaser flow

cc @dennwc