### PR TITLE
libc putchar

### DIFF
--- a/libs/stdio.go
+++ b/libs/stdio.go
@@ -143,6 +143,7 @@ const int _cxgo_EOF = -1;
 #define ftell(f) ((FILE*)f)->Tell()
 #define getc(f) ((FILE*)f)->GetC()
 #define ungetc(c, f) ((FILE*)f)->UnGetC(c)
+#define putchar(v) ((FILE*)stdout)->PutC(c)
 
 void     clearerr(FILE *);
 char    *ctermid(char *);
@@ -168,7 +169,6 @@ int      pclose(FILE *);
 void     perror(const char *);
 FILE    *popen(const char *, const char *);
 int      putc(int, FILE *);
-int      putchar(int);
 int      putc_unlocked(int, FILE *);
 int      putchar_unlocked(int);
 int      puts(const char *);


### PR DESCRIPTION
This is a quick implementation for the `putchar(c)` just by replacing calls with `putc(c, stdio)`.

<sub>DISTRIBUTION STATEMENT “A”. (Approved for public release. Distribution is unlimited.)</sub>

<sub>This material is based upon work supported by DARPA under Contract No. HR001122C0047. Any opinions, findings and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of DARPA.</sub>