### PR TITLE
Fix panic for typdef void

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.examples/
 .idea/
 /dist/
+.vscode/

--- a/convert.go
+++ b/convert.go
@@ -497,7 +497,7 @@ func (g *translator) convertDecl(d *cc.Declaration) []CDecl {
 			conf := g.idents[dname]
 			vt := g.convertTypeRootOpt(conf, dd.Type(), id.Position())
 			if isTypedef && vt == nil {
-				vt = types.IntT(1)
+				vt = types.StructT(nil)
 			}
 			var init Expr
 			if id.Initializer != nil && inCur {

--- a/convert.go
+++ b/convert.go
@@ -496,6 +496,9 @@ func (g *translator) convertDecl(d *cc.Declaration) []CDecl {
 			dname := dd.Name().String()
 			conf := g.idents[dname]
 			vt := g.convertTypeRootOpt(conf, dd.Type(), id.Position())
+			if isTypedef && vt == nil {
+				vt = types.IntT(1)
+			}
 			var init Expr
 			if id.Initializer != nil && inCur {
 				if isTypedef {

--- a/docs/quirks.md
+++ b/docs/quirks.md
@@ -58,3 +58,16 @@ headers bundled into `cxgo`.
 
 It serves two purposes: provides a zero-config experience for common use cases and allows `cxgo` to implement C stdlib
 differently and adapt it to the needs of Go.
+
+### typedef void
+
+Example from struct_FILE.h:
+
+    typedef void _IO_lock_t;
+ 
+    _IO_lock_t *_lock;
+
+For now `cxgo` interprets it as int8_t
+
+
+

--- a/docs/quirks.md
+++ b/docs/quirks.md
@@ -67,7 +67,10 @@ Example from struct_FILE.h:
  
     _IO_lock_t *_lock;
 
-For now `cxgo` interprets it as int8_t
+For now `cxgo` interprets it as 
+
+    typedef struct{} _IO_lock_t;
+
 
 
 


### PR DESCRIPTION

Example from struct_FILE.h:

    typedef void _IO_lock_t;
 
    _IO_lock_t *_lock;

For now `cxgo` interprets it as 

    typedef struct{} _IO_lock_t;
